### PR TITLE
STR-2022 Dynamic Redis List and Sets

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
@@ -27,6 +27,15 @@ public class RedisSinkConfig extends RedisConfig {
     public enum RedisCommand {
         HSET, JSONSET, TSADD, SET, XADD, LPUSH, RPUSH, SADD, ZADD, DEL
     }
+    
+    /**
+     * @author Jonathon Ogden
+     * By default, Redis Sink Connector maps the Kafka Message Key to the entry (element or member) of a Redis List or Set. This option allows the user to change that
+     *
+     */
+    public enum MessageToCollectionEntryMap {
+        KEY, VALUE
+    }
 
     public static final RedisSinkConfigDef CONFIG = new RedisSinkConfigDef();
 
@@ -43,6 +52,8 @@ public class RedisSinkConfig extends RedisConfig {
     private final int waitReplicas;
 
     private final Duration waitTimeout;
+    
+    private final MessageToCollectionEntryMap mapping;
 
     public RedisSinkConfig(Map<?, ?> originals) {
         super(new RedisSinkConfigDef(), originals);
@@ -54,6 +65,7 @@ public class RedisSinkConfig extends RedisConfig {
         multiExec = Boolean.TRUE.equals(getBoolean(RedisSinkConfigDef.MULTIEXEC_CONFIG));
         waitReplicas = getInt(RedisSinkConfigDef.WAIT_REPLICAS_CONFIG);
         waitTimeout = Duration.ofMillis(getLong(RedisSinkConfigDef.WAIT_TIMEOUT_CONFIG));
+        mapping = MessageToCollectionEntryMap.valueOf(getString(RedisSinkConfigDef.MESSAGE_TO_COLLECTION_ENTRY_MAP_CONFIG));        
     }
 
     public Charset getCharset() {
@@ -83,12 +95,16 @@ public class RedisSinkConfig extends RedisConfig {
     public Duration getWaitTimeout() {
         return waitTimeout;
     }
+    
+    public MessageToCollectionEntryMap getMapping() {
+        return mapping;
+    }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + Objects.hash(charset, keyspace, separator, multiExec, command, waitReplicas, waitTimeout);
+        result = prime * result + Objects.hash(charset, keyspace, separator, multiExec, command, waitReplicas, waitTimeout, mapping);
         return result;
     }
 
@@ -103,7 +119,7 @@ public class RedisSinkConfig extends RedisConfig {
         RedisSinkConfig other = (RedisSinkConfig) obj;
         return Objects.equals(charset, other.charset) && Objects.equals(keyspace, other.keyspace)
                 && Objects.equals(separator, other.separator) && multiExec == other.multiExec && command == other.command
-                && waitReplicas == other.waitReplicas && waitTimeout == other.waitTimeout;
+                && waitReplicas == other.waitReplicas && waitTimeout == other.waitTimeout && mapping == other.mapping;
     }
 
 }

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfigDef.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfigDef.java
@@ -12,6 +12,8 @@ import org.apache.kafka.common.config.ConfigValue;
 import com.redis.kafka.connect.common.RedisConfigDef;
 import com.redis.kafka.connect.sink.RedisSinkConfig.RedisCommand;
 
+import com.redis.kafka.connect.sink.RedisSinkConfig.MessageToCollectionEntryMap;
+
 public class RedisSinkConfigDef extends RedisConfigDef {
 
     public static final String TOKEN_TOPIC = "${topic}";
@@ -65,6 +67,12 @@ public class RedisSinkConfigDef extends RedisConfigDef {
     protected static final Set<RedisCommand> MULTI_EXEC_COMMANDS = Stream
             .of(RedisCommand.XADD, RedisCommand.LPUSH, RedisCommand.RPUSH, RedisCommand.SADD, RedisCommand.ZADD)
             .collect(Collectors.toSet());
+    
+    public static final String MESSAGE_TO_COLLECTION_ENTRY_MAP_DOC = "For Redis Lists and Sets, map either the Record's 'Key' or 'Value' to the Redis Collection entry";
+    
+    public static final String MESSAGE_TO_COLLECTION_ENTRY_MAP_CONFIG = "streamkap.messageToCollection.mapping";
+    
+    public static final MessageToCollectionEntryMap MESSAGE_TO_COLLECTION_ENTRY_MAP_DEFAULT = MessageToCollectionEntryMap.KEY;
 
     public RedisSinkConfigDef() {
         define();
@@ -83,6 +91,7 @@ public class RedisSinkConfigDef extends RedisConfigDef {
         define(MULTIEXEC_CONFIG, Type.BOOLEAN, MULTIEXEC_DEFAULT, Importance.MEDIUM, MULTIEXEC_DOC);
         define(WAIT_REPLICAS_CONFIG, Type.INT, WAIT_REPLICAS_DEFAULT, Importance.MEDIUM, WAIT_REPLICAS_DOC);
         define(WAIT_TIMEOUT_CONFIG, Type.LONG, WAIT_TIMEOUT_DEFAULT, Importance.MEDIUM, WAIT_TIMEOUT_DOC);
+        define(MESSAGE_TO_COLLECTION_ENTRY_MAP_CONFIG, Type.STRING, MESSAGE_TO_COLLECTION_ENTRY_MAP_DEFAULT.name(), Importance.LOW, MESSAGE_TO_COLLECTION_ENTRY_MAP_DOC);
     }
 
     @Override
@@ -110,5 +119,4 @@ public class RedisSinkConfigDef extends RedisConfigDef {
     private RedisCommand redisCommand(Map<String, String> props) {
         return RedisCommand.valueOf(props.getOrDefault(COMMAND_CONFIG, COMMAND_DEFAULT.name()));
     }
-
 }


### PR DESCRIPTION
Allows user to configure the Redis Sink Connector to create Redis Lists and Sets per source key. Default behaviour is to create a List or Set per topic.

User can retain default behaviour using the Streamkap-implemented configuration property: `streamkap.messageToCollection.mapping = KEY|VALUE`